### PR TITLE
Adding scopeSize to batch execution

### DIFF
--- a/force-app/main/default/classes/chain_Batch.cls
+++ b/force-app/main/default/classes/chain_Batch.cls
@@ -32,7 +32,7 @@ public inherited sharing abstract class chain_Batch extends chain_Chainable impl
   }
 
   public virtual override void executeChain() {
-    Database.executeBatch(this);
+    Database.executeBatch(this, this.scopeSize);
   }
 
   public override chain_Chainable add(final chain_Chainable aChain) {


### PR DESCRIPTION
I've noticed batch always executes with default scope size, so I added this.scopeSize to batch execution.